### PR TITLE
Add unit tests for Recruiter component and products service

### DIFF
--- a/src/components/Recruiter/Recruiter.test.tsx
+++ b/src/components/Recruiter/Recruiter.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../../commons/style/styled-components';
+import theme from '../../commons/style/theme';
+import Recruiter from './Recruiter';
+
+/**
+ * Recruiter Component Unit Tests
+ * 
+ * This test suite verifies that the Recruiter component renders correctly,
+ * including all its child elements like the thumbnail, flag, heading, and link.
+ */
+describe('[components] - Recruiter', () => {
+  const setup = () => {
+    return render(
+      <ThemeProvider theme={theme}>
+        <Recruiter />
+      </ThemeProvider>
+    );
+  };
+
+  it('should render correctly', () => {
+    const { asFragment } = setup();
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('should display the recruiter thumbnail image', () => {
+    setup();
+    const image = screen.getByAltText('Jeremy Akeze - Doghouse IT Recruitment');
+    expect(image).toBeInTheDocument();
+  });
+
+  it('should display the correct heading with country', () => {
+    setup();
+    const heading = screen.getByText('Work in the Netherlands');
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('should contain a flag element', () => {
+    setup();
+    // Since the flag is a styled span without text, we can test it's parent contains it
+    const heading = screen.getByText('Work in the Netherlands');
+    expect(heading.querySelector('span')).toBeInTheDocument();
+  });
+
+  it('should contain recruiter description text', () => {
+    setup();
+    const description = screen.getByText(/Hi! I'm Jeremy Akeze from Doghouse IT Recruitment/i);
+    expect(description).toBeInTheDocument();
+  });
+
+  it('should include a LinkedIn link', () => {
+    setup();
+    const link = screen.getByText('follow me on Linkedin.');
+    expect(link.tagName).toBe('B');
+    expect(link.closest('a')).toHaveAttribute(
+      'href',
+      'https://www.linkedin.com/in/jeremy-akeze-9542b396/'
+    );
+  });
+});

--- a/src/components/Recruiter/__snapshots__/Recruiter.test.tsx.snap
+++ b/src/components/Recruiter/__snapshots__/Recruiter.test.tsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`[components] - Recruiter should render correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="Recruiter__Container-sc-joc36b-0 kBiQYf"
+  >
+    <div
+      class="Recruiter__Thumbnail-sc-joc36b-1 kjTKfY"
+    >
+      <img
+        alt="Jeremy Akeze - Doghouse IT Recruitment"
+        src="jeremy-akeze-doghouse-it-recruitment.jpg"
+      />
+    </div>
+    <div
+      class="Recruiter__Description-sc-joc36b-3 cHLwtY"
+    >
+      <h4>
+        Work in the Netherlands
+        <span
+          class="Recruiter__Flag-sc-joc36b-2 eJBRMS"
+        />
+      </h4>
+      <p>
+        Hi! I'm Jeremy Akeze from Doghouse IT Recruitment and I'm looking for skilled Software Engineers like you. If you wish to move abroad, 
+        <a
+          href="https://www.linkedin.com/in/jeremy-akeze-9542b396/"
+        >
+          <b>
+            follow me on Linkedin.
+          </b>
+        </a>
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/services/__tests__/products.test.ts
+++ b/src/services/__tests__/products.test.ts
@@ -1,0 +1,63 @@
+import axios from 'axios';
+import { getProducts } from '../products';
+
+/**
+ * Products Service Unit Tests
+ * 
+ * This test suite verifies the functionality of the products service which handles
+ * retrieving products data from either an API endpoint or a local JSON file.
+ */
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('[services] - products', () => {
+  const mockProductsData = {
+    products: [
+      { id: 1, name: 'Product 1' },
+      { id: 2, name: 'Product 2' }
+    ]
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch products from firebase in production environment', async () => {
+    // Mock the process.env.NODE_ENV
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    mockedAxios.get.mockResolvedValueOnce({ data: mockProductsData });
+
+    const result = await getProducts();
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://react-shopping-cart-67954.firebaseio.com/products.json'
+    );
+    expect(result).toEqual(mockProductsData.products);
+
+    // Restore original NODE_ENV
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('should fetch products from local json in non-production environment', async () => {
+    // Mock the process.env.NODE_ENV
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
+    // Mock require function for static json
+    jest.mock('static/json/products.json', () => ({
+      data: mockProductsData
+    }), { virtual: true });
+
+    const result = await getProducts();
+
+    // Axios should not be called in development
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(result).toEqual(mockProductsData.products);
+
+    // Restore original NODE_ENV
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for components and services that were missing test coverage:

1. Added unit tests for the Recruiter component:
   - Tests that the component renders correctly
   - Tests that all elements (image, heading, flag, description, link) render correctly
   - Added snapshot test

2. Added unit tests for the products service:
   - Tests fetching products from Firebase API in production mode
   - Tests fetching products from local JSON file in development mode
   - Includes mocking of axios and environment variables

These tests improve overall test coverage of the codebase and serve as documentation for how these components and services should behave.